### PR TITLE
Fix dead player's showing up

### DIFF
--- a/src/Lua/Hooks/Player/corpse.lua
+++ b/src/Lua/Hooks/Player/corpse.lua
@@ -225,7 +225,16 @@ addHook("ThinkFrame", function()
 			table.remove(MM_N.corpses, _)
 			continue
 		end
-
+		
+		if corpse.playerid -- idk why the MF2_DONTDRAW above is only when the game ends :P, maybe y'all should see that?
+		and (players[corpse.playerid] and players[corpse.playerid].valid)
+		and (players[corpse.playerid].mo and players[corpse.playerid].mo.valid)
+			if not players[corpse.playerid].mo.health
+			and not (players[corpse.playerid].mo.flags2 & MF2_DONTDRAW) then
+				players[corpse.playerid].mo.flags2 = $1|MF2_DONTDRAW
+			end
+		end
+		
 		MM.runHook("CorpseThink", corpse)
 
 		for p in players.iterate do


### PR DESCRIPTION
I think it's more of a band-aid fix, but idk, seems to have fixed dead player's mobjs showing up after dying, further testing should be done i think though
![srb20159](https://github.com/user-attachments/assets/3d76ee6d-b7a4-46f5-8cd3-bacdeaadf13e)

(insert funny thing here)